### PR TITLE
Update MOODLE_22_STABLE

### DIFF
--- a/README
+++ b/README
@@ -6,6 +6,9 @@ Be sure to always install the stable branch that matches your moodle version!
 The master branch is compatible with the latest Moodle and not guarenteed to work on earlier versions.
 If you are on M2.1 for example, you should be installing the copy from the MOODLE_21_STABLE branch.
 
+untar/unzip and move the "netspotau-moodle-mod_lightboxgallery-aa1f7d1" resulted folder within
+moodle/mod folder. Moodle will not detect the new plugin unless you rename it to moodle/mod/lightboxgallery
+
  * ABOUT *
 
 This resource allows you to create 'Lightbox' enabled image galleries within your Moodle course. The


### PR DESCRIPTION
added details for install instructions to address the problem where Moodle 2.2.x doesn't detect the newly installed lightboxgallery, even if it's within the mod folder. it has to be renamed to lightboxgallery.
within moodle/mod, I renamed mine from netspotau-moodle-mod_lightboxgallery-aa1f7d1 to lightboxgallery and then I could install it.

Thanks
