### PR TITLE
Allow captions to be completely hidden.

### DIFF
--- a/imageclass.php
+++ b/imageclass.php
@@ -27,6 +27,7 @@ require_once($CFG->libdir.'/gdlib.php');
 
 define('THUMBNAIL_WIDTH', 162);
 define('THUMBNAIL_HEIGHT', 132);
+define('LIGHTBOXGALLERY_POS_HID', 2);
 define('LIGHTBOXGALLERY_POS_TOP', 1);
 define('LIGHTBOXGALLERY_POS_BOT', 0);
 
@@ -213,6 +214,10 @@ class lightboxgallery_image {
 
         $width = round(100 / $this->gallery->perrow);
 
+        // Hide the caption.
+        if ($this->gallery->captionpos == LIGHTBOXGALLERY_POS_HID) {
+            $caption = ''; // Hide by cleaning the content (looks better than cleaning the whole div).
+        }
         $posclass = ($this->gallery->captionpos == LIGHTBOXGALLERY_POS_TOP) ? 'top' : 'bottom';
         $captiondiv = html_writer::tag('div', $caption, array('class' => "lightbox-gallery-image-caption $posclass"));
 
@@ -226,7 +231,7 @@ class lightboxgallery_image {
                  $this->image_url.'" rel="lightbox_gallery" title="'.$caption.
                  '" style="background-image: url(\''.$this->thumb_url.
                  '\'); width: '.THUMBNAIL_WIDTH.'px; height: '.THUMBNAIL_HEIGHT.'px;"></a>';
-        if ($this->gallery->captionpos == LIGHTBOXGALLERY_POS_BOT) {
+        if ($this->gallery->captionpos == LIGHTBOXGALLERY_POS_BOT or $this->gallery->captionpos == LIGHTBOXGALLERY_POS_HID) {
             $html .= $captiondiv;
         }
         $html .= $this->gallery->extinfo ? '<div class="lightbox-gallery-image-extinfo">'.$timemodified.

--- a/mod_form.php
+++ b/mod_form.php
@@ -70,6 +70,7 @@ class mod_lightboxgallery_mod_form extends moodleform_mod {
         $captionposopts = array(
             '0' => get_string('position_bottom', 'lightboxgallery'),
             '1' => get_string('position_top', 'lightboxgallery'),
+            '2' => get_string('hide'),
         );
         $mform->addElement('select', 'captionpos', get_string('captionpos', 'lightboxgallery'), $captionposopts);
         $mform->setAdvanced('captionpos');


### PR DESCRIPTION
Often it's desirable to completely hide the captions. Right now the only way to achieve this is to go and manually clean them photo by photo (not ideal and tedious).

An alternative would be to allow the cleaning on import, but surely that's not ideal either.

So at the end, I did this small hack that adds a new setting to the "caption position" setting, with value "hide" and that causes all the captions to be 100% hidden (without losing them).

For your consideration, ciao :-)
