### PR TITLE
setTtype in form element

### DIFF
--- a/imageadd_form.php
+++ b/imageadd_form.php
@@ -58,6 +58,7 @@ class mod_lightboxgallery_imageadd_form extends moodleform {
         }
 
         $mform->addElement('hidden', 'id', $cm->id);
+        $mform->setType('id',PARAM_INT);
 
         $this->add_action_buttons(true, get_string('addimage', 'lightboxgallery'));
 


### PR DESCRIPTION
Moodle 2.5 issues a notice if form fields are not explicitly typed.
