### PR TITLE
M2.9 compatibility - fix intro editor function call

### DIFF
--- a/mod_form.php
+++ b/mod_form.php
@@ -48,7 +48,11 @@ class mod_lightboxgallery_mod_form extends moodleform_mod {
         $mform->addRule('name', null, 'required', null, 'client');
         $mform->addRule('name', get_string('maximumchars', '', 255), 'maxlength', 255, 'client');
 
-        $this->add_intro_editor(true, get_string('description'));
+        if ($CFG->branch < 29) {
+            $this->add_intro_editor(true, get_string('description'));
+        } else {
+            $this->standard_intro_elements();
+        }
 
         // Advanced options.
 


### PR DESCRIPTION
Fixes deprecated warning with Moodle 2.9 (whilst maintaining Moodle 2.8 compatibility).