### PR TITLE
GAO-406 - Replaced PARAM_INTEGER occurrences

### DIFF
--- a/edit/thumbnail/thumbnail.class.php
+++ b/edit/thumbnail/thumbnail.class.php
@@ -65,16 +65,20 @@ class edit_thumbnail extends edit_base {
             $offset = optional_param('offset', 20, PARAM_INT);
             switch ($move) {
                 case 1:
-                    $offsetx = 0; $offsety = -$offset;
+                    $offsetx = 0;
+                    $offsety = -$offset;
                     break;
                 case 2:
-                    $offsetx = 0; $offsety = $offset;
+                    $offsetx = 0;
+                    $offsety = $offset;
                     break;
                 case 3:
-                    $offsetx = -$offset; $offsety = 0;
+                    $offsetx = -$offset;
+                    $offsety = 0;
                     break;
                 case 4:
-                    $offsetx = $offset; $offsety = 0;
+                    $offsetx = $offset;
+                    $offsety = 0;
                     break;
                 default:
                     $domove = false;

--- a/mod_form.php
+++ b/mod_form.php
@@ -59,7 +59,7 @@ class mod_lightboxgallery_mod_form extends moodleform_mod {
         $mform->addElement('header', 'galleryoptions', get_string('advanced'));
 
         $mform->addElement('select', 'perpage', get_string('imagesperpage', 'lightboxgallery'), $this->get_perpage_options());
-        $mform->setType('perpage', PARAM_INTEGER);
+        $mform->setType('perpage', PARAM_INT);
 
         $yesno = array(0 => get_string('no'), 1 => get_string('yes'));
 
@@ -79,32 +79,32 @@ class mod_lightboxgallery_mod_form extends moodleform_mod {
                                 $this->get_autoresize_options());
         $autoresizegroup[] = $mform->createElement('checkbox', 'autoresizedisabled', null, get_string('disable'));
         $mform->addGroup($autoresizegroup, 'autoresizegroup', get_string('autoresize', 'lightboxgallery'), ' ', false);
-        $mform->setType('autoresize', PARAM_INTEGER);
+        $mform->setType('autoresize', PARAM_INT);
         $mform->disabledIf('autoresizegroup', 'autoresizedisabled', 'checked');
         $mform->addHelpButton('autoresizegroup', 'autoresize', 'lightboxgallery');
 
         $mform->addElement('select', 'resize', sprintf('%s (%s)', get_string('edit_resize', 'lightboxgallery'),
                             core_text::strtolower(get_string('upload'))), lightboxgallery_resize_options());
-        $mform->setType('resize', PARAM_INTEGER);
+        $mform->setType('resize', PARAM_INT);
         $mform->disabledIf('resize', 'autoresize', 'eq', 1);
         $mform->disabledIf('resize', 'autoresizedisabled', 'checked');
 
         $mform->addElement('select', 'comments', get_string('allowcomments', 'lightboxgallery'), $yesno);
-        $mform->setType('comments', PARAM_INTEGER);
+        $mform->setType('comments', PARAM_INT);
 
         $mform->addElement('select', 'ispublic', get_string('makepublic', 'lightboxgallery'), $yesno);
-        $mform->setType('ispublic', PARAM_INTEGER);
+        $mform->setType('ispublic', PARAM_INT);
 
         if (lightboxgallery_rss_enabled()) {
             $mform->addElement('select', 'rss', get_string('allowrss', 'lightboxgallery'), $yesno);
-            $mform->setType('rss', PARAM_INTEGER);
+            $mform->setType('rss', PARAM_INT);
         } else {
             $mform->addElement('static', 'rssdisabled', get_string('allowrss', 'lightboxgallery'),
                                 get_string('rssglobaldisabled', 'admin'));
         }
 
         $mform->addElement('select', 'extinfo', get_string('extendedinfo', 'lightboxgallery'), $yesno);
-        $mform->setType('extinfo', PARAM_INTEGER);
+        $mform->setType('extinfo', PARAM_INT);
 
         // Module options.
 


### PR DESCRIPTION
Hello,

Remote-Learner (RL) has received a request to load this latest version 2016052400 dated 2016/07/03 of your plugin mod_lightboxgallery into the RL environment, and have approved this version 2016052400 on Moodle 3.1 as all features seem to work with no problem.  Prior to any external code being loaded onto our environment, the systems group performs a review of the code to validate that the plugin is compliant with our standards. The review consists of an automated code test, followed by a manual review.  The automated test is done primarily so that the code does not introduce any security issues onto our sites, and for conformance to POET ( http://poetgroup.org/ ) coding standards.  The POET standard includes the Moodle coding standard, plus some additional security tests developed by POET.  I am just submitting this pull request to fix some non-critical warnings which do not affect plugin operation, but which were thrown as part of the automated checks:

- ./mod_form.php: 62, 82, 88, 93, 96, 100, 107 | ERROR | The use of the constant PARAM_INTEGER is strongly discouraged. Use 'PARAM_INT' instead.

- ./edit/thumbnail/thumbnail.class.php: 68, 71, 74, 77 | ERROR | [x] Each PHP statement must be on a line by itself

Please feel free to contact if you have any questions, otherwise I’ll just watch for any new versions as part of our regular update checks for this plugin.