### PR TITLE
Remove redundant / from the thumnail URL

### DIFF
--- a/imageclass.php
+++ b/imageclass.php
@@ -53,7 +53,7 @@ class lightboxgallery_image {
 
         $this->imageurl = $CFG->wwwroot.'/pluginfile.php/'.$this->context->id.'/mod_lightboxgallery/gallery_images/'.
                            $this->storedfile->get_itemid().$this->storedfile->get_filepath().$this->storedfile->get_filename();
-        $this->thumburl = $CFG->wwwroot.'/pluginfile.php/'.$this->context->id.'/mod_lightboxgallery/gallery_thumbs/0/'.
+        $this->thumburl = $CFG->wwwroot.'/pluginfile.php/'.$this->context->id.'/mod_lightboxgallery/gallery_thumbs/0'.
                            $this->storedfile->get_filepath().$this->storedfile->get_filename().'.png';
 
         $imageinfo = $this->storedfile->get_imageinfo();


### PR DESCRIPTION
Since the file path starts with a slash having `gallery_thumbs/0'.$this->storedfile->get_filepath()` leads to a double slash in the URL. Starting with Moodle 3.3 (or depending on the config even earlier) it leads to errors which cause the thumbnails to not to be displayed. 

This simple change fixes the issue.